### PR TITLE
readBAM: The last underscore separates the barcode

### DIFF
--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -258,7 +258,7 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
 
             /* Parse the index from the readName */
             std::string index = "", readNameSpl = "";
-            std::size_t found = readName.find("_");
+            std::size_t found = readName.rfind("_");
             if (found!=std::string::npos)
                 readNameSpl = readName.substr(found+1);
             if (checkIndex(readNameSpl))


### PR DESCRIPTION
Previously the first underscore separated the barcode, which was not
compatible with read identifiers that included an underscore, such as
the output of LRSIM.