### PR TITLE
Barcode multiplicity fix

### DIFF
--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -250,8 +250,6 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
     size_t linecount = 0;
     const unsigned int suppAligFlag = 0x00000800;
 
-    int notPrim = 0;
-
     // Number of unpaired reads.
     size_t countUnpaired = 0;
 

--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -249,6 +249,7 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
     std::string line;
     size_t linecount = 0;
     const unsigned int suppAligFlag = 0x00000800;
+    const unsigned int notPrimaryAligFlag = 0x00000100;
 
     // Number of unpaired reads.
     size_t countUnpaired = 0;
@@ -288,7 +289,6 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
                 }
             }
         } else {
-
             linecount++;
 
             std::stringstream ss(line);
@@ -311,9 +311,9 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
                       index.clear();
                 }
             }
-
-            /* Keep track of index multiplicity if it is not supplementary alignment */
-            if (!index.empty() && !(flag & suppAligFlag))
+            
+            /* Keep track of index multiplicity if alignment is not supplementary alignment and is not non-primary alignment*/
+            if (!index.empty() && !((flag & suppAligFlag) || (flag & notPrimaryAligFlag)))
                 indexMultMap[index]++;
 
             /* Calculate the sequence identity */

--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -248,6 +248,9 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
 
     std::string line;
     size_t linecount = 0;
+    const unsigned int suppAligFlag = 0x00000800;
+
+    int notPrim = 0;
 
     // Number of unpaired reads.
     size_t countUnpaired = 0;
@@ -288,19 +291,14 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
             }
         } else {
 
+            linecount++;
+
             std::stringstream ss(line);
             std::string readName, scafName, cigar, rnext, seq, qual, tags;
             int flag, pos, mapq, pnext, tlen;
 
             ss >> readName >> flag >> scafName >> pos >> mapq >> cigar
                 >> rnext >> pnext >> tlen >> seq >> qual >> std::ws;
-
-            /* Ignore if alignment is a supplementary alignment */
-            if(flag >= 2048){
-                continue;
-            }
-
-            linecount++;
 
             getline(ss, tags);
 
@@ -316,8 +314,8 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
                 }
             }
 
-            /* Keep track of index multiplicity */
-            if (!index.empty())
+            /* Keep track of index multiplicity if it is not supplementary alignment */
+            if (!index.empty() && !(flag & suppAligFlag))
                 indexMultMap[index]++;
 
             /* Calculate the sequence identity */

--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -287,7 +287,6 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
                 }
             }
         } else {
-            linecount++;
 
             std::stringstream ss(line);
             std::string readName, scafName, cigar, rnext, seq, qual, tags;
@@ -295,6 +294,13 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
 
             ss >> readName >> flag >> scafName >> pos >> mapq >> cigar
                 >> rnext >> pnext >> tlen >> seq >> qual >> std::ws;
+
+            /* Check if alignment is a primary alignment */
+            if(flag >= 2048){
+                continue;
+            }
+
+            linecount++;
 
             getline(ss, tags);
 
@@ -415,6 +421,8 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
     /* Close BAM file */
     assert_eof(bamName_stream, bamName);
     bamName_stream.close();
+
+    std::cout << "Ended on line " << linecount << std::endl;
 
     if (countUnpaired > 0)
         std::cerr << "Warning: Skipped " << countUnpaired << " unpaired reads. Read pairs should be consecutive in the SAM/BAM file.\n";

--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -295,7 +295,7 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
             ss >> readName >> flag >> scafName >> pos >> mapq >> cigar
                 >> rnext >> pnext >> tlen >> seq >> qual >> std::ws;
 
-            /* Check if alignment is a primary alignment */
+            /* Ignore if alignment is a supplementary alignment */
             if(flag >= 2048){
                 continue;
             }

--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -422,8 +422,6 @@ void readBAM(const std::string bamName, ARCS::IndexMap& imap, std::unordered_map
     assert_eof(bamName_stream, bamName);
     bamName_stream.close();
 
-    std::cout << "Ended on line " << linecount << std::endl;
-
     if (countUnpaired > 0)
         std::cerr << "Warning: Skipped " << countUnpaired << " unpaired reads. Read pairs should be consecutive in the SAM/BAM file.\n";
 }


### PR DESCRIPTION
Supplementary alignments' barcode information is ignored for multiplicity calculation.