### PR TITLE
output pairing information

### DIFF
--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -98,7 +98,7 @@ static const char USAGE_MESSAGE[] =
             "       --dist_upper        use upper bound distance in ABySS dist.gv\n"
             "       --dist_tsv=FILE     write min/max distance estimates to FILE\n"
             "       --samples_tsv=FILE  write intra-contig distance/barcode samples to FILE\n"
-            "   -P, --pair              output scaffolds pairing tsv with number of evidences "
+            "   -P, --pair              output scaffolds pairing TSV with number of barcode links (no p-value threshold)"
             "supporting each of the 4 possible orientation\n";
 
 static const char shortopts[] = "f:a:B:s:c:Dl:z:b:g:m:d:e:r:vt:u:j:k:P";

--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -98,7 +98,8 @@ static const char USAGE_MESSAGE[] =
             "       --dist_upper        use upper bound distance in ABySS dist.gv\n"
             "       --dist_tsv=FILE     write min/max distance estimates to FILE\n"
             "       --samples_tsv=FILE  write intra-contig distance/barcode samples to FILE\n"
-            "   -P, --pair              output scaffolds pairing TSV with number of barcode links (no p-value threshold)"
+            "   -P, --pair              output scaffolds pairing TSV with number of barcode links "
+            "(no p-value threshold)"
             "supporting each of the 4 possible orientation\n";
 
 static const char shortopts[] = "f:a:B:s:c:Dl:z:b:g:m:d:e:r:vt:u:j:k:P";

--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -98,7 +98,8 @@ static const char USAGE_MESSAGE[] =
             "       --dist_upper        use upper bound distance in ABySS dist.gv\n"
             "       --dist_tsv=FILE     write min/max distance estimates to FILE\n"
             "       --samples_tsv=FILE  write intra-contig distance/barcode samples to FILE\n"
-            "   -P, --pair              output scaffolds pairing tsv\n";
+            "   -P, --pair              output scaffolds pairing tsv with number of evidences "
+            "supporting each of the 4 possible orientation\n";
 
 static const char shortopts[] = "f:a:B:s:c:Dl:z:b:g:m:d:e:r:vt:u:j:k:P";
 

--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -97,8 +97,8 @@ static const char USAGE_MESSAGE[] =
             "       --dist_median       use median distance in ABySS dist.gv [default]\n"
             "       --dist_upper        use upper bound distance in ABySS dist.gv\n"
             "       --dist_tsv=FILE     write min/max distance estimates to FILE\n"
-            "       --samples_tsv=FILE  write intra-contig distance/barcode samples to FILE\n";
-"   -P, --pair              output scaffolds pairing tsv\n";
+            "       --samples_tsv=FILE  write intra-contig distance/barcode samples to FILE\n"
+            "   -P, --pair              output scaffolds pairing tsv\n";
 
 static const char shortopts[] = "f:a:B:s:c:Dl:z:b:g:m:d:e:r:vt:u:j:k:P";
 

--- a/Arcs/Arcs.h
+++ b/Arcs/Arcs.h
@@ -46,6 +46,8 @@ struct ArcsParams
 	std::string fofName;
 	int seq_id;
 	int min_reads;
+	/** output pairing information */
+	bool output_pair;
 	/** enable/disable distance estimation on graph edges */
 	bool dist_est;
 	/** bin size when computing distance estimates */


### PR DESCRIPTION
Output pairing tsv for physlr to orient backbone pieces. While the `.gv` contains similar information, that information has been processed. The raw pairing tsv could information for weakly supported pairs if we want to orient smaller pieces.