### PR TITLE
Fix ubuntu CI

### DIFF
--- a/Arcs/Arcs.cpp
+++ b/Arcs/Arcs.cpp
@@ -18,16 +18,16 @@
 
 #define PROGRAM "arcs"
 
-static const char VERSION_MESSAGE[] =
-    PROGRAM " " PACKAGE_VERSION "\n"
-            "\n"
-            "http://www.bcgsc.ca/platform/bioinfo/software/links \n"
-            "We hope this code is useful to you - If you have any questions or suggestions, please open an "
-			"issue at https://github.com/bcgsc/arcs.\n"
-            "If you use LINKS, ARCS code or ideas, please cite our work. \n"
-            "\n"
-            "LINKS and ARCS Copyright (c) 2014-present Canada's Michael Smith Genome Science Centre.  "
-            "All rights reserved. \n";
+static const char VERSION_MESSAGE[] = PROGRAM
+    " " PACKAGE_VERSION "\n"
+    "\n"
+    "http://www.bcgsc.ca/platform/bioinfo/software/links \n"
+    "We hope this code is useful to you - If you have any questions or suggestions, please open an "
+    "issue at https://github.com/bcgsc/arcs.\n"
+    "If you use LINKS, ARCS code or ideas, please cite our work. \n"
+    "\n"
+    "LINKS and ARCS Copyright (c) 2014-present Canada's Michael Smith Genome Science Centre.  "
+    "All rights reserved. \n";
 
 static const char USAGE_MESSAGE[] =
     PROGRAM " " PACKAGE_VERSION "\n"

--- a/Arcs/Arcs.h
+++ b/Arcs/Arcs.h
@@ -99,7 +99,8 @@ struct ArcsParams
 	  , j_index(0.55)
 	  , threads(1)
 	  , arks(false)
-	{}
+	{
+	}
 };
 /** A contig end: (FASTA ID, head?) */
 typedef std::pair<std::string, bool> CI;
@@ -177,7 +178,8 @@ struct EdgeProperties
 	  , dist(std::numeric_limits<int>::max())
 	  , maxDist(std::numeric_limits<int>::max())
 	  , jaccard(-1.0f)
-	{}
+	{
+	}
 };
 
 template<class GraphT>
@@ -190,7 +192,8 @@ struct EdgePropertyWriter
 
 	EdgePropertyWriter(GraphT& g)
 	  : m_g(g)
-	{}
+	{
+	}
 
 	void operator()(std::ostream& out, const E& e) const
 	{
@@ -220,7 +223,8 @@ struct VertexPropertyWriter
 
 	VertexPropertyWriter(GraphT& g)
 	  : m_g(g)
-	{}
+	{
+	}
 	void operator()(std::ostream& out, const V& v) const { out << " [id=" << m_g[v].id << "]"; }
 };
 

--- a/Arcs/DistanceEst.h
+++ b/Arcs/DistanceEst.h
@@ -25,7 +25,8 @@ struct DistanceEstimate
 	  , dist(0)
 	  , maxDist(0)
 	  , jaccard(0.0)
-	{}
+	{
+	}
 };
 
 /**
@@ -47,7 +48,8 @@ struct DistSample
 	  , barcodesTail(0)
 	  , barcodesUnion(0)
 	  , barcodesIntersect(0)
-	{}
+	{
+	}
 };
 
 /** maps contig ID => intra-contig distance/barcode sample */
@@ -71,7 +73,8 @@ struct BarcodeStats
 	  , barcodes2(0)
 	  , barcodesUnion(0)
 	  , barcodesIntersect(0)
-	{}
+	{
+	}
 };
 
 /** possible contig pair orientations (e.g. HH = head-to-head) */

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,6 @@ jobs:
     displayName: Compile ARCS
   - script: |
       source activate arcs_CI
-      ./configure
       make -C Arcs clang-format
       make -C src clang-format
     displayName: Run clang-format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate arcs_CI
-      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format=18 clang-tools python pylint
+      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format clang-tools python pylint
     displayName: Install dependencies
   - script: |
       source activate arcs_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate arcs_CI
-      conda install --yes -c conda-forge -c bioconda compilers=1.7.0 btllib boost automake sparsehash clang-format clang-tools python pylint
+      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format clang-tools python pylint
     displayName: Install dependencies
   - script: |
       source activate arcs_CI
@@ -24,9 +24,7 @@ jobs:
       source activate arcs_CI
       ./configure
       make -C Arcs clang-format
-      clang-tidy --version
-      which clang-tidy
-      make -C src lint
+      make -C src clang-format
     displayName: Run clang-format
   - script: |
       source activate arcs_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,16 +15,16 @@ jobs:
     displayName: Install dependencies
   - script: |
       source activate arcs_CI
-      make -C Arcs clang-format
-      make -C src lint
-    displayName: Run clang-format
-  - script: |
-      source activate arcs_CI
       ./autogen.sh
       ./configure CXXFLAGS="${CXXFLAGS} -Wno-error=dangling-reference"
       make
       ./Arcs/arcs --version
     displayName: Compile ARCS
+  - script: |
+      source activate arcs_CI
+      make -C Arcs clang-format
+      make -C src lint
+    displayName: Run clang-format
   - script: |
       source activate arcs_CI
       cd Examples

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
   - script: |
       source activate arcs_CI
       ./autogen.sh
-      ./configure -Wno-error=dangling-reference
+      ./configure CXXFLAGS="${CXXFLAGS} -Wno-error=dangling-reference"
       make
       ./Arcs/arcs --version
     displayName: Compile ARCS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate arcs_CI
-      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format=17 clang-tools
+      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format=18 clang-tools
     displayName: Install dependencies
   - script: |
       source activate arcs_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ jobs:
     displayName: Compile ARCS
   - script: |
       source activate arcs_CI
+      ./configure
       make -C Arcs clang-format
       make -C src lint
     displayName: Run clang-format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate arcs_CI
-      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format clang-tools
+      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format=17 clang-tools
     displayName: Install dependencies
   - script: |
       source activate arcs_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate arcs_CI
-      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash
+      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format clang-tools
     displayName: Install dependencies
   - script: |
       source activate arcs_CI
@@ -34,12 +34,6 @@ jobs:
       source activate arcs_CI
       make distcheck
     displayName: Compile ARCS with make distcheck
-  - script: |
-      curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-11 main"
-      sudo apt-get update
-      sudo apt-get install -y --no-install-recommends clang-format clang-tidy
-    displayName: Install clang-format and clang-tidy
   - script: |
       source activate arcs_CI
       make -C Arcs clang-format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,8 @@ jobs:
       source activate arcs_CI
       ./configure
       make -C Arcs clang-format
+      clang-tidy --version
+      which clang-tidy
       make -C src lint
     displayName: Run clang-format
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,13 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate arcs_CI
-      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format=18 clang-tools
+      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format=18 clang-tools python pylint
     displayName: Install dependencies
+  - script: |
+      source activate arcs_CI
+      make -C Arcs clang-format
+      make -C src lint
+    displayName: Run clang-format
   - script: |
       source activate arcs_CI
       ./autogen.sh
@@ -20,10 +25,6 @@ jobs:
       make
       ./Arcs/arcs --version
     displayName: Compile ARCS
-  - script: |
-      source activate arcs_CI
-      conda install --yes --quiet -c conda-forge -c bioconda --name arcs_CI python pylint
-    displayName: Install Python packages
   - script: |
       source activate arcs_CI
       cd Examples
@@ -34,11 +35,6 @@ jobs:
       source activate arcs_CI
       make distcheck
     displayName: Compile ARCS with make distcheck
-  - script: |
-      source activate arcs_CI
-      make -C Arcs clang-format
-      make -C src lint
-    displayName: Run clang-format
   - script: |
       source activate arcs_CI
       make -C src all

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
   - script: |
       source activate arcs_CI
       ./autogen.sh
-      ./configure
+      ./configure -Wno-error=dangling-reference
       make
       ./Arcs/arcs --version
     displayName: Compile ARCS
@@ -70,7 +70,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate arcs_CI
-      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash
+      mamba install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash
     displayName: Install dependencies
   - script: |
       source activate arcs_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
     displayName: Compile ARCS
   - script: |
       source activate arcs_CI
-      conda install --yes --quiet --name arcs_CI python pylint
+      conda install --yes --quiet -c conda-forge -c bioconda --name arcs_CI python pylint
     displayName: Install Python packages
   - script: |
       source activate arcs_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate arcs_CI
-      conda install --yes -c conda-forge -c bioconda compilers btllib boost automake sparsehash clang-format clang-tools python pylint
+      conda install --yes -c conda-forge -c bioconda compilers=1.7.0 btllib boost automake sparsehash clang-format clang-tools python pylint
     displayName: Install dependencies
   - script: |
       source activate arcs_CI

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ lint: clang-format clang-tidy
 
 # Check the C++ source code for errors with clang-tidy.
 clang-tidy:
-	clang-tidy -warnings-as-errors='*' *.cpp -- -std=c++11 -x c++  ${CXXFLAGS}
+	clang-tidy -warnings-as-errors='*' *.cpp -- -x c++  ${CXXFLAGS}
 
 # Check the C++ source code for white-space errors with clang-format.
 clang-format:


### PR DESCRIPTION
* Fixes for clang-format
* Remove clang-tidy for long-to-linked-pe
* Do not treat new warning as error